### PR TITLE
fix: Update mobile navbar breakpoint to fit new "Blog" link

### DIFF
--- a/components/Navbar/style.module.css
+++ b/components/Navbar/style.module.css
@@ -8,7 +8,7 @@
 	position: relative;
 	z-index: 5;
 }
-@media (max-width: 520px) {
+@media (max-width: 526px) {
 	.navbar {
 		overflow: visible;
 	}
@@ -40,7 +40,7 @@
 	gap: 20px;
 	padding: 0 20px;
 }
-@media (max-width: 520px) {
+@media (max-width: 526px) {
 	.links {
 		position: absolute;
 		height: var(--navbar-height);
@@ -109,7 +109,7 @@
 	align-items: center;
 	justify-content: center;
 }
-@media (max-width: 520px) {
+@media (max-width: 526px) {
 	.mobileToggle {
 		display: flex;
 	}

--- a/components/Navbar/style.module.css
+++ b/components/Navbar/style.module.css
@@ -8,7 +8,7 @@
 	position: relative;
 	z-index: 5;
 }
-@media (max-width: 470px) {
+@media (max-width: 520px) {
 	.navbar {
 		overflow: visible;
 	}
@@ -40,7 +40,7 @@
 	gap: 20px;
 	padding: 0 20px;
 }
-@media (max-width: 470px) {
+@media (max-width: 520px) {
 	.links {
 		position: absolute;
 		height: var(--navbar-height);
@@ -109,7 +109,7 @@
 	align-items: center;
 	justify-content: center;
 }
-@media (max-width: 470px) {
+@media (max-width: 520px) {
 	.mobileToggle {
 		display: flex;
 	}


### PR DESCRIPTION
The new Blog link in the navbar leaves a small window of screen widths where the longer navbar wraps. This PR makes the mobile navbar show for more screen widths to avoid this.

Before | After
--- | ---
<img width="897" height="334" alt="image" src="https://github.com/user-attachments/assets/8b3e78a5-f18f-427c-9e63-f46a15b234e7" /> |<img width="897" height="357" alt="image" src="https://github.com/user-attachments/assets/ce91acd7-d877-4a52-afc4-2ee9103ba57d" />
